### PR TITLE
Adjust text size

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,6 +52,17 @@ body {
     clear: both;
 }
 
+.welcomeMessage {
+    color:white;
+    font-weight:300;
+}
+
+.header {
+    color:white;
+    line-height:0.9;
+    margin-top: 0.2em;
+}
+
 .colour1 {
     background-color: #3EB890;
     width: 50vh;
@@ -80,7 +91,6 @@ body {
 }
 
 .data {
-    font-size: 4vw !important;
     word-wrap: break-word;
     color: #fff !important;
 }

--- a/index.html
+++ b/index.html
@@ -3,19 +3,19 @@
 <head>
     <!-- Metadata -->
     <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1,maximum-scale=1"
     <meta content="Slack Statistics" name="description">
     <!-- Fonts & CSS -->
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700" rel="stylesheet" type="text/css">
     <link href="css/style.css" rel="stylesheet" type="text/css">
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
     <title>Slack Statistics</title>
-  
 </head>
 <body>
     <a href='https://github.com/pvdsp/slack-statistics' style='position:fixed;padding:5px 45px;width:128px;top:50px;right:-50px;-webkit-transform:rotate(45deg);-moz-transform:rotate(45deg);-ms-transform:rotate(45deg);transform:rotate(45deg);box-shadow:0 0 0 3px #3eb890;text-shadow:0 0 0 #ffffff;background-color:#3eb890;color:#ffffff;font-size:13px;font-family:sans-serif;text-decoration:none;font-weight:bold;border:2px dotted #ffffff;-webkit-backface-visibility:hidden;letter-spacing:.5px;'>Fork me on GitHub</a>
     <center>
-        <h2 style="color:white;line-height:0.3;font-weight:300;"><script src="js/welcomeMessage.js"></script></h2>
-        <h1 style="color:white;line-height:0.3" id="title">Slack statistics for ~</h1>
+        <h2 class="welcomeMessage"><script src="js/welcomeMessage.js"></script></h2>
+        <h1 class="header" id="title">Fetching Slack statistics...</h1>
 
     <div id="stats">
         <div id="messageCounterContainers">


### PR DESCRIPTION

This is my first pull request, so if I've done something wrong just let me know :)

Regarding Issue #12 

-Added in the viewport to fix text scaling (It should display on
mobile/tablet correctly now too).
-Adjusted line-heights and moved inline styling to style.css.
-“Most Talkative User” should now display correctly.
![screen shot 2016-10-25 at 10 32 02 pm](https://cloud.githubusercontent.com/assets/4531223/19684461/ff63b142-9b02-11e6-91ea-1f1a5c3b7772.png)