### PR TITLE
Fix for the unsupported fetch in safari 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,15 @@
+{
+  "name": "slack-statistics",
+  "homepage": "https://github.com/pvdsp/slack-statistics",
+  "authors": [],
+  "description": "",
+  "main": "",
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
             </div>
         </div>
     </center>
+    <script src="bower_components/es6-promise/es6-promise.min.js"></script>
+    <script src="bower_components/fetch/fetch.js"></script>
     <script src="js/stats.js">
     </script>
 </body>

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,7 +1,7 @@
 // Primary JavaScript for Slack Statistics
 
 // Settings and initialisation
-var slackToken = "xoxp-96070264915-96117363732-96134401489-08a08fcbd834f00d1ba6f0dcfe655845";
+var slackToken = "YOUR-TOKEN-HERE";
 
 // Queries
 var todayQuery = "on:today";

--- a/js/stats.js
+++ b/js/stats.js
@@ -1,7 +1,7 @@
 // Primary JavaScript for Slack Statistics
 
 // Settings and initialisation
-var slackToken = "YOUR_TOKEN_HERE";
+var slackToken = "xoxp-96070264915-96117363732-96134401489-08a08fcbd834f00d1ba6f0dcfe655845";
 
 // Queries
 var todayQuery = "on:today";


### PR DESCRIPTION
Added bower to the project, and polyfills for the fetch API and es6 promises.

`npm install -g bower && bower install`

